### PR TITLE
nuvoton: poleg.h: Add kernel reboot on oops/panic to bootargs

### DIFF
--- a/include/configs/poleg.h
+++ b/include/configs/poleg.h
@@ -91,7 +91,7 @@
 		"echo Using bootargs: ${bootargs};bootm ${uimage_flash_addr}\0" \
 		"autostart=yes\0"   \
 		"eth_num=0\0"    \
-		"common_bootargs=setenv bootargs earlycon=${earlycon} root=/dev/ram console=${console} mem=${mem} ramdisk_size=48000 basemac=${ethaddr}\0"   \
+		"common_bootargs=setenv bootargs earlycon=${earlycon} root=/dev/ram console=${console} mem=${mem} ramdisk_size=48000 basemac=${ethaddr} oops=panic panic=20\0"   \
 		"ftp_prog=setenv ethact eth${eth_num}; dhcp; tftp 10000000 image-bmc; cp.b 10000000 80000000 ${filesize}\0"   \
 		"ftp_run=setenv ethact eth${eth_num}; dhcp; tftp 10000000 image-bmc; bootm 10200000\0"   \
 		"sd_prog=fatload mmc 0 10000000 image-bmc; cp.b 10000000 80000000 ${filesize}\0"  \


### PR DESCRIPTION
Set bootargs to make linux kernel trigger panic on oops, and reboot 20 seconds after panic.

This is crucial for production environment where the BMC needs to recover from kernel panics.

Tested:
  root:~# cat /proc/sys/kernel/panic
  20
  root:~# cat /proc/sys/kernel/panic_on_oops
  1

  Manually trigger kernel panic and observe BMC rebooted after 20
  seconds:
  root@arcadia:~# echo c > /proc/sysrq-trigger

Signed-off-by: Kun Yi <kunyi@google.com>