### PR TITLE
dts: npcm730 GBS: add event clear to GPIO59

### DIFF
--- a/arch/arm/dts/nuvoton-npcm730-gbs-pincfg.dtsi
+++ b/arch/arm/dts/nuvoton-npcm730-gbs-pincfg.dtsi
@@ -159,6 +159,7 @@
 			bias-disable;
 			input-enable;
 			persist-enable;
+			event-clear;
 		};
 		gpio60ol_pins: gpio60ol-pins {
 			pins = "GPIO60/SMB3DSCL";


### PR DESCRIPTION
GPIO59 is for interrupt and need to clear events after reboot

Signed-off-by: George Hung <george.hung@quantatw.com>