### PR TITLE
dts: npcm730 GBS: add event clear to some GPIs and init GPIO74

### DIFF
--- a/arch/arm/dts/nuvoton-npcm730-gbs-pincfg.dtsi
+++ b/arch/arm/dts/nuvoton-npcm730-gbs-pincfg.dtsi
@@ -14,6 +14,7 @@
 			bias-disable;
 			input-enable;
 			persist-enable;
+			event-clear;
 		};
 		gpio6o_pins:gpio6o-pins {
 			pins = "GPIO6/IOX2CK/SMB2DSDA";
@@ -147,12 +148,14 @@
 			bias-disable;
 			input-enable;
 			persist-enable;
+			event-clear;
 		};
 		gpio58_pins: gpio58-pins {
 			pins = "GPIO58/R1MDIO";
 			bias-disable;
 			input-enable;
 			persist-enable;
+			event-clear;
 		};
 		gpio59_pins: gpio59-pins {
 			pins = "GPIO59/SMB3DSDA";
@@ -172,6 +175,7 @@
 			bias-disable;
 			input-enable;
 			persist-enable;
+			event-clear;
 		};
 		gpio70_pins: gpio70-pins {
 			pins = "GPIO70/FANIN6";
@@ -200,6 +204,12 @@
 			input-enable;
 			persist-enable;
 			event-clear;
+		};
+		gpio74ol_pins: gpio74ol_pins {
+			pins = "GPIO74/FANIN10";
+			bias-disable;
+			output-low;
+			persist-enable;
 		};
 		gpio76o_pins: gpio76o-pins {
 			pins = "GPIO76/FANIN12";
@@ -308,12 +318,14 @@
 			bias-disable;
 			input-enable;
 			persist-enable;
+			event-clear;
 		};
 		gpio121_pins: gpio121-pins {
 			pins = "GPIO121/SMB2CSCL";
 			bias-disable;
 			input-enable;
 			persist-enable;
+			event-clear;
 		};
 		gpio122_pins: gpio122-pins {
 			pins = "GPIO122/SMB2BSDA";

--- a/arch/arm/dts/nuvoton-npcm730-gbs.dts
+++ b/arch/arm/dts/nuvoton-npcm730-gbs.dts
@@ -25,6 +25,7 @@
 				&gpio19ol_pins
 				&gpio25ol_pins
 				&gpio60ol_pins
+				&gpio74ol_pins
 				&gpio76o_pins
 				&gpio77ol_pins
 				&gpio78ol_pins


### PR DESCRIPTION
1. add event clear to GPIO05/57/58/69/120/121
2. initialize GPIO74 as output low

Signed-off-by: George Hung <george.hung@quantatw.com>