### PR TITLE
dts: npcm730 GBS: fix the GPIO91 setting

### DIFF
--- a/arch/arm/dts/nuvoton-npcm730-gbs-pincfg.dtsi
+++ b/arch/arm/dts/nuvoton-npcm730-gbs-pincfg.dtsi
@@ -270,11 +270,10 @@
 			output-low;
 			persist-enable;
 		};
-		gpio91ol_pins: gpio91ol-pins {
+		gpio91o_pins: gpio91o-pins {
 			pins = "GPIO91/R2MDC";
 			bias-disable;
-			active-low;
-			output-low;
+			output-high;
 			persist-enable;
 		};
 		gpio92_pins: gpio92-pins {

--- a/arch/arm/dts/nuvoton-npcm730-gbs.dts
+++ b/arch/arm/dts/nuvoton-npcm730-gbs.dts
@@ -35,7 +35,7 @@
 				&gpio87ol_pins
 				&gpio89ol_pins
 				&gpio90ol_pins
-				&gpio91ol_pins
+				&gpio91o_pins
 				&gpio94ol_pins
 				&gpio110ol_pins
 				&gpio111ol_pins


### PR DESCRIPTION
It should be only set output-high for GPIO91

Signed-off-by: George Hung <george.hung@quantatw.com>