### PR TITLE
Npcm7xx v2019.01: Fii kudo project dts & dtsi files

### DIFF
--- a/arch/arm/dts/nuvoton-npcm730-kudo-pincfg.dtsi
+++ b/arch/arm/dts/nuvoton-npcm730-kudo-pincfg.dtsi
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2020 Fii USA Inc. 
+// Maintainer: Brandon Ong <Brandon.Ong@fii-na.com>
+
+/ {
+	pinctrl: pinctrl@f0800000 {	
+		gpio50i_pins: gpio50i-pins {
+			pins = "GPIO50/nCTS2";
+			bias-disable;
+			input-enable;
+		};
+		gpio51oh_pins: gpio51oh-pins {
+			pins = "GPO51/nRTS2/STRAP2";
+			bias-disable;
+			output-high;
+		};
+		gpio52i_pins: gpio52i-pins {
+			pins = "GPIO52/nDCD2";
+			bias-disable;
+			input-enable;
+		};
+		gpio53oh_pins: gpio53oh-pins {
+			pins = "GPO53/nDTR2_BOUT2/STRAP1";
+			bias-disable;
+			output-high;
+		};
+		gpio54i_pins: gpio54i-pins {
+			pins = "GPIO54/nDSR2";
+			bias-disable;
+			input-enable;
+		};
+		gpio55ol_pins: gpio55ol-pins {
+			pins = "GPIO55/nRI2";
+			bias-disable;
+			output-low;
+		};
+		gpio61oh_pins: gpio61oh-pins {
+			pins = "GPO61/nDTR1_BOUT1/STRAP6";
+			bias-disable;
+			output-high;
+		};
+		gpio62oh_pins: gpio62oh-pins {
+			pins = "GPO62/nRTST1/STRAP5";
+			bias-disable;
+			output-high;
+		};
+		gpio63oh_pins: gpio63oh-pins {
+			pins = "GPO63/TXD1/STRAP4";
+			bias-disable;
+			output-high;
+		};
+		gpio64oh_pins: gpio64oh-pins {
+			pins = "GPIO64/FANIN0";
+			bias-disable;
+			output-high;
+		};
+		gpio65ol_pins: gpio65ol-pins {
+			pins = "GPIO65/FANIN1";
+			bias-disable;
+			output-low;
+		};
+		gpio66oh_pins: gpio66oh-pins {
+			pins = "GPIO66/FANIN2";
+			bias-disable;
+			output-high;
+		};
+		gpio67oh_pins: gpio67oh-pins {
+			pins = "GPIO67/FANIN3";
+			bias-disable;
+			output-high;
+		};
+		gpio68ol_pins: gpio68ol-pins {
+			pins = "GPIO68/FANIN4";
+			bias-disable;
+			output-low;
+		};
+		gpio69i_pins: gpio69i-pins {
+			pins = "GPIO69/FANIN5";
+			bias-disable;
+			input-enable;
+		};
+		gpio70ol_pins: gpio70ol-pins {
+			pins = "GPIO70/FANIN6";
+			bias-disable;
+			output-low;
+		};
+		gpio71i_pins: gpio71i-pins {
+			pins = "GPIO71/FANIN7";
+			bias-disable;
+			input-enable;
+		};
+		gpio72i_pins: gpio72i-pins {
+			pins = "GPIO72/FANIN8";
+			bias-disable;
+			input-enable;
+		};
+		gpio73i_pins: gpio73i-pins {
+			pins = "GPIO73/FANIN9";
+			bias-disable;
+			input-enable;
+		};
+		gpio74i_pins: gpio74i-pins {
+			pins = "GPIO74/FANIN10";
+			bias-disable;
+			input-enable;
+		};
+		gpio75i_pins: gpio75i-pins {
+			pins = "GPIO75/FANIN11";
+			bias-disable;
+			input-enable;
+		};
+		gpio76i_pins: gpio76i-pins {
+			pins = "GPIO76/FANIN12";
+			bias-disable;
+			input-enable;
+		};
+		gpio77i_pins: gpio77i-pins {
+			pins = "GPIO77/FANIN13";
+			bias-disable;
+			input-enable;
+		};
+		gpio78i_pins: gpio78i-pins {
+			pins = "GPIO78/FANIN14";
+			bias-disable;
+			input-enable;
+		};
+		gpio79ol_pins: gpio79ol-pins {
+			pins = "GPIO79/FANIN15";
+			bias-disable;
+			output-low;
+		};
+		gpio80oh_pins: gpio80oh-pins {
+			pins = "GPIO80/PWM0";
+			bias-disable;
+			output-high;
+		};
+		gpio81i_pins: gpio81i-pins {
+			pins = "GPIO81/PWM1";
+			bias-disable;
+			input-enable;
+		};
+		gpio82i_pins: gpio82i-pins {
+			pins = "GPIO82/PWM2";
+			bias-disable;
+			input-enable;
+		};
+		gpio83i_pins: gpio83i-pins {
+			pins = "GPIO83/PWM3";
+			bias-disable;
+			input-enable;
+		};
+		gpio95i_pins: gpio95i-pins {
+			pins = "GPIO95/nLRESET/nESPIRST";
+			bias-disable;
+			input-enable;
+		};
+		gpio120i_pins: gpio120i-pins {
+			pins = "GPIO120/SMB2CSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio121i_pins: gpio121i-pins {
+			pins = "GPIO121/SMB2CSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio122i_pins: gpio122i-pins {
+			pins = "GPIO122/SMB2BSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio123i_pins: gpio123i-pins {
+			pins = "GPIO123/SMB2BSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio124i_pins: gpio124i-pins {
+			pins = "GPIO124/SMB1CSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio125i_pins: gpio125i-pins {
+			pins = "GPIO125/SMB1CSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio126i_pins: gpio126i-pins {
+			pins = "GPIO126/SMB1BSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio127i_pins: gpio127i-pins {
+			pins = "GPIO127/SMB1BSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio136i_pins: gpio136i-pins {
+			pins = "GPIO136/SD1DT0";
+			bias-disable;
+			input-enable;
+		};
+		gpio137oh_pins: gpio137oh-pins {
+			pins = "GPIO137/SD1DT1";
+			bias-disable;
+			output-high;
+		};
+		gpio138i_pins: gpio138i-pins {
+			pins = "GPIO138/SD1DT2";
+			bias-disable;
+			input-enable;
+		};
+		gpio139i_pins: gpio139i-pins {
+			pins = "GPIO139/SD1DT3";
+			bias-disable;
+			input-enable;
+		};
+		gpio140i_pins: gpio140i-pins {
+			pins = "GPIO140/SD1CLK";
+			bias-disable;
+			input-enable;
+		};
+		gpio141i_pins: gpio141i-pins {
+			pins = "GPIO141/SD1WP";
+			bias-disable;
+			input-enable;
+		};
+		gpio144i_pins: gpio144i-pins {
+			pins = "GPIO144/PWM4";
+			bias-disable;
+			input-enable;
+		};
+		gpio145i_pins: gpio145i-pins {
+			pins = "GPIO145/PWM5";
+			bias-disable;
+			input-enable;
+		};
+		gpio146i_pins: gpio146i-pins {
+			pins = "GPIO146/PWM6";
+			bias-disable;
+			input-enable;
+		};
+		gpio147oh_pins: gpio147oh-pins {
+			pins = "GPIO147/PWM7";
+			bias-disable;
+			output-high;
+		};
+		gpio161ol_pins: gpio161ol-pins {
+			pins = "GPIO161/nLFRAME/nESPICS";
+			bias-disable;
+			output-low;
+		};
+		gpio162oh_pins: gpio162oh-pins {
+			pins = "GPIO162/SERIRQ";
+			bias-disable;
+			output-high;
+		};
+		gpio163i_pins: gpio163i-pins {
+			pins = "GPIO163/LCLK/ESPICLK";
+			bias-disable;
+			input-enable;
+		};
+		gpio167ol_pins: gpio167ol-pins {
+			pins = "GPIO167/LAD3/ESPI_IO3";
+			bias-disable;
+			output-low;
+		};
+		gpio168ol_pins: gpio168ol-pins {
+			pins = "GPIO168/nCLKRUN/nESPIALERT";
+			bias-disable;
+			output-low;
+		};
+		gpio169oh_pins: gpio169oh-pins {
+			pins = "GPIO169/nSCIPME";
+			bias-disable;
+			output-high;
+		};
+		gpio170ol_pins: gpio170ol-pins {
+			pins = "GPIO170/nSMI";
+			bias-disable;
+			output-low;
+		};
+		gpio175oh_pins: gpio175oh-pins {
+			pins = "GPIO175/PSPI1CK/FANIN19";
+			bias-disable;
+			output-high;
+		};
+		gpio176ol_pins: gpio176ol-pins {
+			pins = "GPIO176/PSPI1DO/FANIN18";
+			bias-disable;
+			output-low;
+		};
+		gpio177i_pins: gpio177i-pins {
+			pins = "GPIO177/PSPI1DI/FANIN17";
+			bias-disable;
+			input-enable;
+		};
+		gpio190oh_pins: gpio190oh-pins {
+			pins = "GPIO190/nPRD_SMI";
+			bias-disable;
+			output-high;
+		};
+		gpio191oh_pins: gpio191oh-pins {
+			pins = "GPIO191";
+			bias-disable;
+			output-high;
+		};
+		gpio194oh_pins: gpio194oh-pins {
+			pins = "GPIO194/SMB0BSCL";
+			bias-disable;
+			output-high;
+		};
+		gpio195ol_pins: gpio195ol-pins {
+			pins = "GPIO195/SMB0BSDA";
+			bias-disable;
+			output-low;
+		};
+		gpio196ol_pins: gpio196ol-pins {
+			pins = "GPIO196/SMB0CSCL";
+			bias-disable;
+			output-low;
+		};
+		gpio197oh_pins: gpio197oh-pins {
+			pins = "GPIO197/SMB0DEN";
+			bias-disable;
+			output-high;
+		};
+		gpio199i_pins: gpio199i-pins {
+			pins = "GPIO199/SMB0DSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio202ol_pins: gpio202ol-pins {
+			pins = "GPIO202/SMB0CSDA";
+			bias-disable;
+			output-low;
+		};
+		gpio203ol_pins: gpio203ol-pins {
+			pins = "GPIO203/FANIN16";
+			bias-disable;
+			output-low;
+		};
+		gpio218oh_pins: gpio218oh-pins {
+			pins = "GPIO218/nWDO1";
+			bias-disable;
+			output-high;
+		};
+		gpio219oh_pins: gpio219oh-pins {
+			pins = "GPIO219/nWDO2";
+			bias-disable;
+			output-high;
+		};
+	};
+};

--- a/arch/arm/dts/nuvoton-npcm730-kudo.dts
+++ b/arch/arm/dts/nuvoton-npcm730-kudo.dts
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2020 Fii USA Inc. 
+// Maintainer: Brandon Ong <Brandon.Ong@fii-na.com>
+
+/dts-v1/;
+#include "nuvoton-common-npcm7xx.dtsi"
+#include "nuvoton-npcm730-kudo-pincfg.dtsi"
+
+/ {
+	model = "Fii Kudo Board (Device Tree v00.01)";
+	compatible = "nuvoton,poleg", "kudo";
+
+	chosen {
+		stdout-path = &serial0;
+		tick-timer = &timer0;
+	};
+
+	aliases {
+		serial0 = &serial0;
+		serial1 = &serial1;
+		serial2 = &serial2;
+		serial3 = &serial3;
+		i2c0 = &i2c0;
+		i2c1 = &i2c1;
+		i2c2 = &i2c2;
+		i2c3 = &i2c3;
+		i2c4 = &i2c4;
+		i2c5 = &i2c5;
+		i2c6 = &i2c6;
+		i2c7 = &i2c7;
+		i2c8 = &i2c8;
+		i2c9 = &i2c9;
+		i2c10 = &i2c10;
+		i2c11 = &i2c11;
+		i2c12 = &i2c12;
+		i2c13 = &i2c13;
+		i2c14 = &i2c14;
+		i2c15 = &i2c15;
+		spi0 = &fiu0;
+		spi3 = &fiu3;
+		spi4 = &fiux;
+		spi5 = &pspi1;
+		mmc1 = &sdhci1;
+		gpio0 = &gpio0;
+		gpio1 = &gpio1;
+		gpio2 = &gpio2;
+		gpio3 = &gpio3;
+		gpio4 = &gpio4;
+		gpio5 = &gpio5;
+		gpio6 = &gpio6;
+		gpio7 = &gpio7;
+		usb0 = &usbd0;
+		eth0 = &emc0;
+		eth1 = &gmac0;
+	};
+
+	fiu0: fiu0@fb000000 {
+		pinctrl-names = "default";
+		pinctrl-0 = <&spi0cs1_pins>;
+		status = "okay";
+		spi_flash@0 {
+			compatible = "spi-flash";
+			reg = <0>; /* Chip select 0 */
+			memory-map = <0x80000000 0x4000000>;
+		};
+		spi_flash@1 {
+			compatible = "spi-flash";
+			reg = <1>;
+			memory-map = <0x88000000 0x4000000>;
+		};
+	};
+
+	fiu3: fiu3@c0000000 {
+		status = "okay";
+		pinctrl-names = "default";
+		pinctrl-0 = <&spi3_pins
+			&spi3quad_pins>;
+		spi_flash@0 {
+			compatible = "spi-flash";
+			reg = <0>; /* Chip select 0 */
+			memory-map = <0xA0000000 0x8000000>;
+		};
+	};
+
+	fiux: fiux@fb001000 {
+		status = "okay";
+		spi_flash@0 {
+			compatible = "spi-flash";
+			reg = <0>; /* Chip select 0 */
+		 };
+	};
+
+	pspi1: pspi1@f0200000 {
+		status = "okay";
+	};
+
+	usbd0: usbd0@f0830100 {
+		status = "okay";
+	};
+
+
+	sdhci1: sdhci1@f0842000 {
+		status = "okay";
+	};
+
+	otp: otp@f0189000 {
+		status = "okay";
+	};
+
+	rng: rng@f000b000 {
+		status = "okay";
+	};
+
+	aes: aes@f0858000 {
+		status = "okay";
+	};
+
+	sha: sha@f085a000 {
+		status = "okay";
+	};
+
+	gmac0: gmac0@f0802000 {
+		status = "okay";
+	};
+
+	emc0: emc0@f0825000 {
+		status = "okay";
+		pinctrl-names = "default";
+		pinctrl-0 = <&r1_pins
+			&r1err_pins>;
+		fixed-link {
+			speed = <100>;
+			full-dulpex;
+		};
+	};
+
+	ehci: ehci {
+		status = "okay";
+	};
+
+	i2c0: i2c-bus@f0080000 {
+		status = "okay";
+	};
+
+	i2c1: i2c-bus@f0081000 {
+		status = "okay";
+	};
+
+	i2c2: i2c-bus@f0082000 {
+		status = "okay";
+	};
+
+	i2c3: i2c-bus@f0083000 {
+		status = "okay";
+	};
+
+	i2c4: i2c-bus@f0084000 {
+		status = "okay";
+	};
+
+	i2c5: i2c-bus@f0085000 {
+		status = "okay";
+	};
+
+	i2c6: i2c-bus@f0086000 {
+		status = "okay";
+	};
+
+	i2c7: i2c-bus@f0087000 {
+		status = "okay";
+	};
+
+	i2c8: i2c-bus@f0088000 {
+		status = "okay";
+	};
+
+	i2c9: i2c-bus@f0089000 {
+		status = "okay";
+	};
+
+	i2c10: i2c-bus@f008a000 {
+		status = "okay";
+	};
+
+	i2c11: i2c-bus@f008b000 {
+		status = "okay";
+	};
+
+	i2c12: i2c-bus@f008c000 {
+		status = "okay";
+	};
+
+	i2c13: i2c-bus@f008d000 {
+		status = "okay";
+	};
+
+	i2c14: i2c-bus@f008e000 {
+		status = "okay";
+	};
+
+	i2c15: i2c-bus@f008f000 {
+		status = "okay";
+	};
+
+	pinctrl: pinctrl@f0800000 {
+		compatible = "nuvoton,npcm7xx-pinctrl";
+	        pinctrl-names = "default";
+		pinctrl-0 = <
+	                &gpio50i_pins
+		        &gpio51oh_pins
+			&gpio52i_pins
+	                &gpio53oh_pins
+		        &gpio54i_pins
+			&gpio55ol_pins
+	                &gpio61oh_pins
+		        &gpio62oh_pins
+			&gpio63oh_pins
+	                &gpio64oh_pins
+		        &gpio65ol_pins
+			&gpio66oh_pins
+	                &gpio67oh_pins
+		        &gpio68ol_pins
+			&gpio69i_pins
+	                &gpio70ol_pins
+		        &gpio71i_pins
+			&gpio72i_pins
+	                &gpio73i_pins
+		        &gpio74i_pins
+			&gpio75i_pins
+	                &gpio76i_pins
+		        &gpio77i_pins
+			&gpio78i_pins
+	                &gpio79ol_pins
+		        &gpio80oh_pins
+			&gpio81i_pins
+	                &gpio82i_pins
+		        &gpio83i_pins
+			&gpio95i_pins
+	                &gpio120i_pins
+		        &gpio121i_pins
+			&gpio122i_pins
+	                &gpio123i_pins
+		        &gpio124i_pins
+			&gpio125i_pins
+	                &gpio126i_pins
+		        &gpio127i_pins
+			&gpio136i_pins
+	                &gpio137oh_pins
+		        &gpio138i_pins
+			&gpio139i_pins
+	                &gpio140i_pins
+		        &gpio141i_pins
+			&gpio144i_pins
+	                &gpio145i_pins
+		        &gpio146i_pins
+	                &gpio147oh_pins
+		        &gpio161ol_pins
+	                &gpio162oh_pins
+		        &gpio163i_pins
+	                &gpio167ol_pins
+		        &gpio168ol_pins
+	                &gpio169oh_pins
+		        &gpio170ol_pins
+	                &gpio175oh_pins
+		        &gpio176ol_pins
+	                &gpio177i_pins
+		        &gpio190oh_pins
+	                &gpio191oh_pins
+		        &gpio194oh_pins
+			&gpio195ol_pins
+	                &gpio196ol_pins
+		        &gpio197oh_pins
+	                &gpio199i_pins
+		        &gpio202ol_pins
+			&gpio203ol_pins
+	                &gpio218oh_pins
+		        &gpio219oh_pins
+			>;
+	};
+};


### PR DESCRIPTION
Foxconn create the dts&dtsi for the kudo project, it base on the Ampere CPU and the npcm730 chipset