### PR TITLE
dts: npcm730 kudo: update gpios in dts/dtsi

### DIFF
--- a/arch/arm/dts/nuvoton-npcm730-kudo-pincfg.dtsi
+++ b/arch/arm/dts/nuvoton-npcm730-kudo-pincfg.dtsi
@@ -4,350 +4,643 @@
 
 / {
 	pinctrl: pinctrl@f0800000 {	
-		gpio50i_pins: gpio50i-pins {
-			pins = "GPIO50/nCTS2";
-			bias-disable;
-			input-enable;
-		};
-		gpio51oh_pins: gpio51oh-pins {
-			pins = "GPO51/nRTS2/STRAP2";
+		/* LED Pins*/
+		gpio7oh_pins: gpio7oh-pins {
+                        pins = "GPIO7/IOX2D0/SMB2DSCL";
+                        label = "LED_BMC_LIVE";
+                        bias-disable;
+                        output-low;
+                };
+		gpio24ol_pins: gpio24ol-pins {
+                        pins = "GPIO24/IOXHDO";
+                        label = "BMC_FAULT_LED";
+                        bias-disable;
+                        output-low;
+                };   
+                gpio169ol_pins: gpio169ol-pins {
+                        pins = "GPIO169/nSCIPME";
+                        label = "SYS_ERR_LED";
+                        bias-disable;
+                        output-low;
+                };
+
+		// JTAG Pins
+		gpio17_pins: gpio17-pins{
+                        pins = "GPIO17/PSPI2DI/SMB4DEN";
+                        bias-disable;
+                        input-enable;   
+                };
+                gpio18o_pins: gpio18o-pins{
+			pins = "GPIO18/PSPI2D0/SMB4BSDA";
 			bias-disable;
 			output-high;
-		};
-		gpio52i_pins: gpio52i-pins {
-			pins = "GPIO52/nDCD2";
-			bias-disable;
-			input-enable;
-		};
-		gpio53oh_pins: gpio53oh-pins {
-			pins = "GPO53/nDTR2_BOUT2/STRAP1";
-			bias-disable;
-			output-high;
-		};
-		gpio54i_pins: gpio54i-pins {
-			pins = "GPIO54/nDSR2";
-			bias-disable;
-			input-enable;
-		};
-		gpio55ol_pins: gpio55ol-pins {
-			pins = "GPIO55/nRI2";
+                };
+                gpio19ol_pins: gpio19ol-pins{
+			pins = "GPIO19/PSPI2CK/SMB4BSCL";
 			bias-disable;
 			output-low;
-		};
-		gpio61oh_pins: gpio61oh-pins {
-			pins = "GPO61/nDTR1_BOUT1/STRAP6";
-			bias-disable;
-			output-high;
-		};
-		gpio62oh_pins: gpio62oh-pins {
-			pins = "GPO62/nRTST1/STRAP5";
-			bias-disable;
-			output-high;
-		};
-		gpio63oh_pins: gpio63oh-pins {
-			pins = "GPO63/TXD1/STRAP4";
-			bias-disable;
-			output-high;
-		};
-		gpio64oh_pins: gpio64oh-pins {
-			pins = "GPIO64/FANIN0";
-			bias-disable;
-			output-high;
-		};
-		gpio65ol_pins: gpio65ol-pins {
-			pins = "GPIO65/FANIN1";
-			bias-disable;
-			output-low;
-		};
-		gpio66oh_pins: gpio66oh-pins {
-			pins = "GPIO66/FANIN2";
-			bias-disable;
-			output-high;
-		};
-		gpio67oh_pins: gpio67oh-pins {
-			pins = "GPIO67/FANIN3";
-			bias-disable;
-			output-high;
-		};
-		gpio68ol_pins: gpio68ol-pins {
-			pins = "GPIO68/FANIN4";
-			bias-disable;
-			output-low;
-		};
-		gpio69i_pins: gpio69i-pins {
-			pins = "GPIO69/FANIN5";
-			bias-disable;
-			input-enable;
-		};
-		gpio70ol_pins: gpio70ol-pins {
-			pins = "GPIO70/FANIN6";
-			bias-disable;
-			output-low;
-		};
-		gpio71i_pins: gpio71i-pins {
-			pins = "GPIO71/FANIN7";
-			bias-disable;
-			input-enable;
-		};
-		gpio72i_pins: gpio72i-pins {
-			pins = "GPIO72/FANIN8";
-			bias-disable;
-			input-enable;
-		};
-		gpio73i_pins: gpio73i-pins {
-			pins = "GPIO73/FANIN9";
-			bias-disable;
-			input-enable;
-		};
-		gpio74i_pins: gpio74i-pins {
-			pins = "GPIO74/FANIN10";
-			bias-disable;
-			input-enable;
-		};
-		gpio75i_pins: gpio75i-pins {
-			pins = "GPIO75/FANIN11";
-			bias-disable;
-			input-enable;
-		};
-		gpio76i_pins: gpio76i-pins {
-			pins = "GPIO76/FANIN12";
-			bias-disable;
-			input-enable;
-		};
-		gpio77i_pins: gpio77i-pins {
-			pins = "GPIO77/FANIN13";
-			bias-disable;
-			input-enable;
-		};
-		gpio78i_pins: gpio78i-pins {
-			pins = "GPIO78/FANIN14";
-			bias-disable;
-			input-enable;
-		};
-		gpio79ol_pins: gpio79ol-pins {
-			pins = "GPIO79/FANIN15";
-			bias-disable;
-			output-low;
-		};
-		gpio80oh_pins: gpio80oh-pins {
-			pins = "GPIO80/PWM0";
-			bias-disable;
-			output-high;
-		};
-		gpio81i_pins: gpio81i-pins {
-			pins = "GPIO81/PWM1";
-			bias-disable;
-			input-enable;
-		};
-		gpio82i_pins: gpio82i-pins {
-			pins = "GPIO82/PWM2";
-			bias-disable;
-			input-enable;
-		};
-		gpio83i_pins: gpio83i-pins {
-			pins = "GPIO83/PWM3";
-			bias-disable;
-			input-enable;
-		};
-		gpio95i_pins: gpio95i-pins {
-			pins = "GPIO95/nLRESET/nESPIRST";
-			bias-disable;
-			input-enable;
-		};
-		gpio120i_pins: gpio120i-pins {
-			pins = "GPIO120/SMB2CSDA";
-			bias-disable;
-			input-enable;
-		};
-		gpio121i_pins: gpio121i-pins {
-			pins = "GPIO121/SMB2CSCL";
-			bias-disable;
-			input-enable;
-		};
-		gpio122i_pins: gpio122i-pins {
-			pins = "GPIO122/SMB2BSDA";
-			bias-disable;
-			input-enable;
-		};
-		gpio123i_pins: gpio123i-pins {
-			pins = "GPIO123/SMB2BSCL";
-			bias-disable;
-			input-enable;
-		};
-		gpio124i_pins: gpio124i-pins {
-			pins = "GPIO124/SMB1CSDA";
-			bias-disable;
-			input-enable;
-		};
-		gpio125i_pins: gpio125i-pins {
-			pins = "GPIO125/SMB1CSCL";
-			bias-disable;
-			input-enable;
-		};
-		gpio126i_pins: gpio126i-pins {
-			pins = "GPIO126/SMB1BSDA";
-			bias-disable;
-			input-enable;
-		};
-		gpio127i_pins: gpio127i-pins {
-			pins = "GPIO127/SMB1BSCL";
-			bias-disable;
-			input-enable;
-		};
-		gpio136i_pins: gpio136i-pins {
-			pins = "GPIO136/SD1DT0";
-			bias-disable;
-			input-enable;
-		};
-		gpio137oh_pins: gpio137oh-pins {
-			pins = "GPIO137/SD1DT1";
-			bias-disable;
-			output-high;
-		};
-		gpio138i_pins: gpio138i-pins {
-			pins = "GPIO138/SD1DT2";
-			bias-disable;
-			input-enable;
-		};
-		gpio139i_pins: gpio139i-pins {
-			pins = "GPIO139/SD1DT3";
-			bias-disable;
-			input-enable;
-		};
-		gpio140i_pins: gpio140i-pins {
-			pins = "GPIO140/SD1CLK";
-			bias-disable;
-			input-enable;
-		};
-		gpio141i_pins: gpio141i-pins {
-			pins = "GPIO141/SD1WP";
-			bias-disable;
-			input-enable;
-		};
-		gpio144i_pins: gpio144i-pins {
-			pins = "GPIO144/PWM4";
-			bias-disable;
-			input-enable;
-		};
-		gpio145i_pins: gpio145i-pins {
-			pins = "GPIO145/PWM5";
-			bias-disable;
-			input-enable;
-		};
-		gpio146i_pins: gpio146i-pins {
-			pins = "GPIO146/PWM6";
-			bias-disable;
-			input-enable;
-		};
-		gpio147oh_pins: gpio147oh-pins {
-			pins = "GPIO147/PWM7";
-			bias-disable;
-			output-high;
-		};
-		gpio161ol_pins: gpio161ol-pins {
-			pins = "GPIO161/nLFRAME/nESPICS";
-			bias-disable;
-			output-low;
-		};
-		gpio162oh_pins: gpio162oh-pins {
-			pins = "GPIO162/SERIRQ";
-			bias-disable;
-			output-high;
-		};
-		gpio163i_pins: gpio163i-pins {
-			pins = "GPIO163/LCLK/ESPICLK";
-			bias-disable;
-			input-enable;
-		};
-		gpio167ol_pins: gpio167ol-pins {
-			pins = "GPIO167/LAD3/ESPI_IO3";
-			bias-disable;
-			output-low;
-		};
-		gpio168ol_pins: gpio168ol-pins {
-			pins = "GPIO168/nCLKRUN/nESPIALERT";
-			bias-disable;
-			output-low;
-		};
-		gpio169oh_pins: gpio169oh-pins {
-			pins = "GPIO169/nSCIPME";
-			bias-disable;
-			output-high;
-		};
-		gpio170ol_pins: gpio170ol-pins {
-			pins = "GPIO170/nSMI";
-			bias-disable;
-			output-low;
-		};
-		gpio175oh_pins: gpio175oh-pins {
-			pins = "GPIO175/PSPI1CK/FANIN19";
-			bias-disable;
-			output-high;
-		};
-		gpio176ol_pins: gpio176ol-pins {
-			pins = "GPIO176/PSPI1DO/FANIN18";
-			bias-disable;
-			output-low;
-		};
-		gpio177i_pins: gpio177i-pins {
-			pins = "GPIO177/PSPI1DI/FANIN17";
-			bias-disable;
-			input-enable;
-		};
-		gpio190oh_pins: gpio190oh-pins {
-			pins = "GPIO190/nPRD_SMI";
-			bias-disable;
-			output-high;
-		};
-		gpio191oh_pins: gpio191oh-pins {
-			pins = "GPIO191";
-			bias-disable;
-			output-high;
-		};
-		gpio194oh_pins: gpio194oh-pins {
-			pins = "GPIO194/SMB0BSCL";
-			bias-disable;
-			output-high;
-		};
-		gpio195ol_pins: gpio195ol-pins {
-			pins = "GPIO195/SMB0BSDA";
-			bias-disable;
-			output-low;
-		};
-		gpio196ol_pins: gpio196ol-pins {
-			pins = "GPIO196/SMB0CSCL";
-			bias-disable;
-			output-low;
-		};
-		gpio197oh_pins: gpio197oh-pins {
-			pins = "GPIO197/SMB0DEN";
-			bias-disable;
-			output-high;
-		};
-		gpio199i_pins: gpio199i-pins {
-			pins = "GPIO199/SMB0DSCL";
-			bias-disable;
-			input-enable;
-		};
-		gpio202ol_pins: gpio202ol-pins {
-			pins = "GPIO202/SMB0CSDA";
-			bias-disable;
-			output-low;
-		};
-		gpio203ol_pins: gpio203ol-pins {
-			pins = "GPIO203/FANIN16";
-			bias-disable;
-			output-low;
-		};
-		gpio218oh_pins: gpio218oh-pins {
-			pins = "GPIO218/nWDO1";
-			bias-disable;
-			output-high;
-		};
-		gpio219oh_pins: gpio219oh-pins {
-			pins = "GPIO219/nWDO2";
-			bias-disable;
-			output-high;
-		};
+                };
+		
+
+                /* Mux Pins */
+                // UART Mux Pins
+                gpio167oh_pins: gpio167oh-pins {
+                        pins = "GPIO167/LAD3/ESPI_IO3";
+                        label = "S0_UART0_BMC_SEL";
+                        bias-disable;
+                        output-high;
+                };   
+                gpio161oh_pins: gpio161oh-pins {
+                        pins = "GPIO161/nLFRAME/nESPICS";
+                        label = "S0_UART1_BMC_SEL";
+                        bias-disable;
+                        output-high;
+                };   
+		gpio177oh_pins: gpio177oh-pins {
+                        pins = "GPIO177/PSPI1DI/FANIN17";
+                        label = "S1_UART1_BMC_SEL";
+                        bias-disable;
+                        output-high;
+                };
+                gpio198ol_pins: gpio198ol-pins {
+                        pins = "GPIO198/SMB0DSDA";
+                        label = "SX_BMC_UART1_SEL";     
+                        bias-disable;
+                        output-low;
+                };
+
+                // I2C Mux Pins
+                gpio87oh_pins: gpio87oh-pins {
+                        pins = "GPIO87/R2RXD0";
+                        label = "BMC_I2C0_MUX4_RST_N";
+                        bias-disable;
+                        output-high;
+                };
+                gpio88oh_pins: gpio88oh-pins {
+                        pins = "GPIO88/R2RXD1";
+                        label = "BMC_I2C1_MUX1_RST_N";
+                        bias-disable;
+                        output-high;
+                };
+                gpio89oh_pins: gpio89oh-pins {
+                        pins = "GPIO89/R2CRSDV";
+                        label = "BMC_I2C1_MUX2_RST_N";
+                        bias-disable;
+                        output-high;
+                };
+                gpio91oh_pins: gpio91oh-pins {
+                        pins = "GPIO91/R2MDC";
+                        label = "BMC_I2C4_MUX3_RST_N";
+                        bias-disable;
+                        output-high;
+                };
+                gpio168oh_pins: gpio168oh-pins {
+                        pins = "GPIO168/nCLKRUN/nESPIALERT";
+                        label = "BMC_I2C_BACKUP_SEL";
+                        bias-disable;
+                        output-high;
+                };
+
+                // I3C Mux Pin
+                gpio12oh_pins: gpio12oh-pins{
+                        pins = "GPIO12/GSPICK/SMB5BSCL";
+                        label = "I3C_MUX_RST_N";
+                        bias-disable;
+                        output-high;
+                };
+
+                // JTAG Mux Pins
+                gpio218oh_pins: gpio218oh-pins {
+                        pins = "GPIO218/nWDO1";
+                        label = "BMC_JTAG_MUX_1";
+                        bias-disable;
+                        output-high;
+                };
+                gpio164ol_pins: gpio164ol-pins {
+                        pins = "GPIO164/LAD0/ESPI_IO0";
+                        label = "BMC_JTAG_SEL";
+                        bias-disable;
+                        output-low;
+                };
+                gpio16oh_pins: gpio16oh-pins {
+                        pins = "GPIO16/LKGPO0";
+                        label = "JTAG_TMS_BMC_MUX";
+                        bias-disable;
+                        output-high;
+                };
+
+                // CPU Mux Pins
+                gpio84ol_pins: gpio84ol-pins {
+                        pins = "GPIO84/R2TXD0";
+                        label = "BMC_CPU_DDR_I2C_SEL";
+                        bias-disable;
+                        output-low;
+                };
+                gpio85ol_pins: gpio85ol-pins {
+                        pins = "GPIO85/R2TXD1";
+                        label = "BMC_CPU_EEPROM_I2C_SEL";
+                        bias-disable;
+                        output-low;
+                };
+                gpio86ol_pins: gpio86ol-pins {
+                        pins = "GPIO86/R2TXEN";
+                        label = "BMC_CPU_PMBUS_SEL";
+                        bias-disable;
+                        output-low;
+                };
+                gpio120ol_pins: gpio120ol-pins {
+                        pins = "GPIO120/SMB2CSDA";
+                        label = "BMC_CPU_RTC_I2C_SEL";
+                        bias-disable;
+                        output-low;
+                };
+
+                /* Control Pins */
+                //gpio10oh_pins: gpio10oh-pins {
+                gpio10ol_pins: gpio10ol-pins {
+                        pins = "GPIO10/IOXHLD";
+                        label = "MON_BMC_ALIVE";
+                        bias-disable;
+                        output-low;
+                };
+		//gpio69oh_pins: gpio69oh-pins {
+		gpio69ol_pins: gpio69ol-pins {
+                        pins = "GPIO69/FANIN5";
+                        label = "S0_BMC_OK";
+                        bias-disable;
+                        //output-high;
+                        output-low;
+                };
+                gpio94ol_pins: gpio94ol-pins {
+                        pins = "GPIO94/nKBRST/SMB5DSDA";
+                        label = "VIRTUAL_RESEAT";
+                        bias-disable;
+                        output-low;
+                };
+		gpio203ol_pins: gpio203ol-pins {        
+                        pins = "GPIO203/FANIN16";
+                        label = "BMC_PWRBTN_OUT";
+                        bias-disable;
+                        output-low;
+		};
+		// graceful shutdown trigger
+                gpio70oh_pins: gpio70oh-pins {
+                        pins = "GPIO70/FANIN6";
+                        label = "S0_SHD_REQ_N";
+                        persist-enable;
+                        output-high;
+                };
+                gpio90oh_pins: gpio90oh-pins {
+                        pins = "GPIO90/R2RXERR";
+                        label = "BMC_I2C4_IO_EXPANDER_RST_N";
+                        bias-disable;
+                        output-high;
+                };
+                gpio196ol_pins: gpio196ol-pins {
+                        pins = "GPIO196/SMB0CSCL";
+                        label = "BMC_JTAG_DAISYCHAIN_DIS";
+                        bias-disable;
+                        output-low;
+                };
+                gpio197oh_pins: gpio197oh-pins {
+                        pins = "GPIO197/SMB0DEN";
+                        label = "FULL_SPEED_N";
+                        bias-disable;
+                        output-high;
+                };
+                gpio14oh_pins: gpio14oh-pins {
+                        pins = "GPIO14/GSPIDI/SMB5CSCL";
+                        label = "PE_THROTTLE_N";
+                        bias-disable;
+                        output-high;
+                };
+                gpio66ol_pins: gpio66ol-pins {
+                        pins = "GPIO66/FANIN2";
+                        label = "S0_PLIMIT";
+                        bias-disable;
+                        output-low;
+                };
+                gpio67ol_pins: gpio67ol-pins {
+                        pins = "GPIO67/FANIN3";
+                        label = "S0_RTC_LOCK";
+                        bias-disable;
+                        output-low;
+                };
+                gpio125ol_pins: gpio125ol-pins {
+                        pins = "GPIO125/SMB1CSCL";
+                        label = "S1_PLIMIT";
+                        bias-disable;
+                        output-low;
+                };
+                gpio4ol_pins: gpio4ol-pins {
+                        pins = "GPIO4/IOX2DI/SMB1DSDA";
+                        label = "RST_POST_N";
+                        bias-disable;
+                        output-low;
+                };
+                gpio5ol_pins: gpio5ol-pins {
+                        pins = "GPIO5/IOX2LD/SMB1DSCL";
+                        label = "JTAG_MUX_R_EN_N";
+                        bias-disable;
+                        output-low;
+                };
+                gpio46ol_pins: gpio46ol-pins {
+                        pins = "GPIO46/nDSR1/JTCK2";
+                        label = "ROT_CPU_RST_N";
+                        bias-disable;
+                        output-low;
+                };
+                gpio187ol_pins: gpio187ol-pins {
+                        pins = "GPIO187/nSPI3CS1";
+                        label = "BMC_FWSPI_HOLD_R_N";
+                        bias-disable;
+                        output-low;
+                };
+                gpio165ol_pins: gpio165ol-pins {
+                        pins = "GPIO165/LAD1/ESPI_IO1";
+                        label = "BMC_JTAG_SPARE";
+                        bias-disable;
+                        output-low;
+                };
+                gpio166ol_pins: gpio166ol-pins {
+                        pins = "GPIO166/LAD2/ESPI_IO2";
+                        label = "BMC_JTAG_SRST_N";
+                        bias-disable;
+                        output-low;
+                };
+                gpio77oh_pins: gpio77oh-pins {
+                        pins = "GPIO77/FANIN13";
+                        label = "S0_DDR_SAVE";
+                        bias-disable;
+                        output-high;
+                };
+                gpio170ol_pins: gpio170ol-pins {
+                        pins = "GPIO170/nSMI";
+                        label = "BMC_I2C6_RESET_N";
+                        bias-disable;
+                        output-low;
+                };
+		gpio175ol_pins: gpio175ol-pins {
+                        pins = "GPIO175/PSPI1CK/FANIN19";
+                        label = "BMC_FWSPI_WP_R_N";
+                        bias-disable;
+                        output-low;
+                };
+                gpio206oh_pins: gpio206oh-pins {
+                        pins = "GPIO206/HSYNC2";
+                        label = "FM_BMC_FRU_EEPROM_WP";
+                        bias-disable;
+                        output-high;
+                };
+                gpio219oh_pins: gpio219oh-pins {
+                        pins = "GPIO219/nWDO2";
+                        label = "BMC_I2C7_RST_N";
+                        bias-disable;
+                        output-high;
+                };
+                gpio15oh_pins: gpio15oh-pins {
+                        pins = "GPIO15/GSPICS/SMB5CSDA";
+                        label = "PE4_BRICK_EN";
+                        bias-disable;
+                        output-high;
+                };
+                gpio139ol_pins: gpio139ol-pins {
+                        pins = "GPIO139/SD1DT3";
+                        label = "HSC_A_FAULT_N";
+                        bias-disable;
+                        output-low;
+                };
+                gpio141oh_pins: gpio141oh-pins {
+                        pins = "GPIO141/SD1WP";
+                        label = "PLD_SYS_RST_BT_N";
+                        bias-disable;
+                        output-high;
+                };
+                gpio202ol_pins: gpio202ol-pins {
+                        pins = "GPIO202/SMB0CSDA";
+                        label = "BMC_SYS_PSON_N";
+                        bias-disable;
+                        output-low;
+                };
+
+                /* Monitor Pins */
+                gpio192i_pins: gpio192i-pins {
+                        pins = "GPIO192";
+                        label = "BMC_PWR_BTN_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio199i_pins: gpio199i-pins {
+                        pins = "GPIO199/SMB0DSCL";
+                        label = "BMC_PSU_PG";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio13i_pins: gpio13i-pins {
+                        pins = "GPIO13/GSPIDO/SMB5BSDA";
+                        label = "S0_RESET_OUT_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio25i_pins: gpio25i-pins {
+                        pins = "GPIO25/IOXHDI";
+                        label = "S1_I2C9_ALERT_R_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio59i_pins: gpio59i-pins {
+                        pins = "GPIO59/SMB3DSDA";
+                        label = "SATA0_PRSNT_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio60i_pins: gpio60i-pins {
+                        pins = "GPIO60/SMB3DSCL";
+                        label = "S0_SCP_AUTH_FAILURE_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio6i_pins: gpio6i-pins {
+                        pins = "GPIO6/IOX2CK/SMB2DSDA";
+                        label = "IRQ_SMB_AGORA_MAX34451_ALERT_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio11i_pins: gpio11i-pins {
+                        pins = "GPIO11/IOXHCK";
+                        label = "S0_I2C4_ALERT_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio162i_pins: gpio162i-pins {
+                        pins = "GPIO162/SERIRQ";
+                        label = "S1_BMC_SPARE_R";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio163i_pins: gpio163i-pins {
+                        pins = "GPIO163/LCLK/ESPICLK";
+                        label = "S0_BMC_VRD3_P0V75_FAULT_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio37i_pins: gpio37i-pins {
+                        pins = "GPIO37/SMB3CSDA";
+                        label = "S1_BMC_VRD3_P0V75_FAULT_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio93i_pins: gpio93i-pins {
+                        pins = "GPIO93/GA20/SMB5DSCL";
+                        label = "FAN_FAIL_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio64i_pins: gpio64i-pins {
+                        pins = "GPIO64/FANIN0";
+                        label = "BMC_S0_GPIO0_DDR_ADR";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio68i_pins: gpio68i-pins {
+                        pins = "GPIO68/FANIN4";
+                        label = "S0_I2C3_ALERT_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio71i_pins: gpio71i-pins {
+                        pins = "GPIO71/FANIN7";
+                        label = "S1_SLAVE_PRESENT_BUFF_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio72i_pins: gpio72i-pins {
+                        pins = "GPIO72/FANIN8";
+                        label = "S0_OVERTEMP_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio73i_pins: gpio73i-pins {
+                        pins = "GPIO73/FANIN9";
+                        label = "S0_HIGHTEMP_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio74i_pins: gpio74i-pins {
+                        pins = "GPIO74/FANIN10";
+                        label = "S0_FAULT_ALERT_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio75i_pins: gpio75i-pins {
+                        pins = "GPIO75/FANIN11";
+                        label = "S0_SHD_ACK_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio76i_pins: gpio76i-pins {
+                        pins = "GPIO76/FANIN12";
+                        label = "S0_REBOOT_ACK_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio78i_pins: gpio78i-pins {
+                        pins = "GPIO78/FANIN14";
+                        label = "S0_PRESENT_CPLD_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio79i_pins: gpio79i-pins {
+                        pins = "GPIO79/FANIN15";
+                        label = "S01_ALERT3_SALT3_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio80i_pins: gpio80i-pins {
+                        pins = "GPIO80/PWM0";
+                        label = "S1_GPI2_SPECIAL_BOOT";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio81i_pins: gpio81i-pins {
+                        pins = "GPIO81/PWM1";
+                        label = "S0_BMC_VRD0_VDDC_FAULT_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio82i_pins: gpio82i-pins {
+                        pins = "GPIO82/PWM2";
+                        label = "S0_BMC_VRD1_VDDQ0123_FAULT_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio83i_pins: gpio83i-pins {
+                        pins = "GPIO83/PWM3";
+                        label = "S1_BMC_VRD2_VDDQ4567_FAULT_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio144i_pins: gpio144i-pins {
+                        pins = "GPIO144/PWM4";
+                        label = "S1_BMC_VRD1_VDDQ0123_FAULT_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio145i_pins: gpio145i-pins {
+                        pins = "GPIO145/PWM5";
+                        label = "S1_BMC_VRD0_VDDC_FAULT_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio146i_pins: gpio146i-pins {
+                        pins = "GPIO146/PWM6";
+                        label = "S0_BMC_VRD2_VDDQ4567_FAULT_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio147i_pins: gpio147i-pins {
+                        pins = "GPIO147/PWM7";
+                        label = "S0_BMC_GPIOAC5_R";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio160i_pins: gpio160i-pins {
+                        pins = "GPIO160/CLKOUT/RNGOSCOUT";
+                        label = "RST_BMC_MB_MAX34451_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio231i_pins: gpio231i-pins {
+                        pins = "GPIO231/nCLKREQ";
+                        label = "FM_SYS_THROTTLE_LVC3_PLD";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio9i_pins: gpio9i-pins {
+                        pins = "GPIO9/LKGPO2";
+                        label = "FM_SEQ_BMC_PCIRST_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio38i_pins: gpio38i-pins {
+                        pins = "GPIO38/SMB3CSCL";
+                        label = "BMC_SALT1_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio39i_pins: gpio39i-pins {
+                        pins = "GPIO39/SMB3BSDA";
+                        label = "BMC_SALT8_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio40i_pins: gpio40i-pins {
+                        pins = "GPIO40/SMB3BSCL";
+                        label = "BMC_SALT0_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio92i_pins: gpio92i-pins {
+                        pins = "GPIO92/R2MDIO";
+                        label = "BMC_SMB_ALERT_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio121i_pins: gpio121i-pins {
+                        pins = "GPIO121/SMB2CSCL";
+                        label = "S1_OVERTEMP_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio122i_pins: gpio122i-pins {
+                        pins = "GPIO122/SMB2BSDA";
+                        label = "S1_SCP_AUTH_FAILURE_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio123i_pins: gpio123i-pins {
+                        pins = "GPIO123/SMB2BSCL";
+                        label = "S1_FW_BOOT_OK";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio124i_pins: gpio124i-pins {
+                        pins = "GPIO124/SMB1CSDA";
+                        label = "S1_FAULT_ALERT_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio126i_pins: gpio126i-pins {
+                        pins = "GPIO126/SMB1BSDA";
+                        label = "S1_HIGHTEMP_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio136i_pins: gpio136i-pins {
+                        pins = "GPIO136/SD1DT0";
+                        label = "S1_PRESENT_CPLD_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio138i_pins: gpio138i-pins {
+                        pins = "GPIO138/SD1DT2";
+                        label = "CPU_BIOS_RECOVER_JMPR";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio140i_pins: gpio140i-pins {
+                        pins = "GPIO140/SD1CLK";
+                        label = "PLD_BMC_SRST_N";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio142i_pins: gpio142i-pins {
+                        pins = "GPIO142/SD1CMD";
+                        label = "ROT_CPU_RST_AUTH_N";
+                        bias-disable;
+                        input-enable;
+                };
+		// fiu3
+                gpio188o_pins: gpio188o-pins {
+                        pins = "GPIO188/SPI3D2/nSPI3CS2";
+                        bias-disable;
+                        output-high;
+                };  
+                gpio189_pins: gpio189-pins {
+                        pins = "GPIO189/SPI3D3/nSPI3CS3";
+                        bias-disable;
+                        input-enable;
+                };  		
+                gpio190i_pins: gpio190i-pins{
+                        pins = "GPIO190/nPRD_SMI";
+                        label = "S0_GPI2_SPECIAL_BOOT";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio194i_pins: gpio194i-pins {
+                        pins = "GPIO194/SMB0BSCL";
+                        label = "S0_FW_BOOT_OK";
+                        bias-disable;
+                        input-enable;
+                };
+                gpio195i_pins: gpio195i-pins {
+                        pins = "GPIO195/SMB0BSDA";
+                        label = "BMC_CON1_SEL";
+                        bias-disable;
+                        input-enable;
+                };
+		// CPU Reset set to high after BMC OK
+                gpio65oh_pins: gpio65oh-pins {
+                        pins = "GPIO65/FANIN1";
+                        label = "BMC_S0_SYSRESET_N";
+                        bias-disable;
+                        output-high;
+                };
+                gpio127oh_pins: gpio127oh-pins {
+                        pins = "GPIO127/SMB1BSCL";
+                        label = "BMC_S1_SYSRESET_N";
+                        bias-disable;
+                        output-high;
+                };
 	};
 };

--- a/arch/arm/dts/nuvoton-npcm730-kudo.dts
+++ b/arch/arm/dts/nuvoton-npcm730-kudo.dts
@@ -206,75 +206,121 @@
 		compatible = "nuvoton,npcm7xx-pinctrl";
 	        pinctrl-names = "default";
 		pinctrl-0 = <
-	                &gpio50i_pins
-		        &gpio51oh_pins
-			&gpio52i_pins
-	                &gpio53oh_pins
-		        &gpio54i_pins
-			&gpio55ol_pins
-	                &gpio61oh_pins
-		        &gpio62oh_pins
-			&gpio63oh_pins
-	                &gpio64oh_pins
-		        &gpio65ol_pins
-			&gpio66oh_pins
-	                &gpio67oh_pins
-		        &gpio68ol_pins
-			&gpio69i_pins
-	                &gpio70ol_pins
-		        &gpio71i_pins
-			&gpio72i_pins
-	                &gpio73i_pins
-		        &gpio74i_pins
-			&gpio75i_pins
-	                &gpio76i_pins
-		        &gpio77i_pins
-			&gpio78i_pins
-	                &gpio79ol_pins
-		        &gpio80oh_pins
-			&gpio81i_pins
-	                &gpio82i_pins
-		        &gpio83i_pins
-			&gpio95i_pins
-	                &gpio120i_pins
-		        &gpio121i_pins
-			&gpio122i_pins
-	                &gpio123i_pins
-		        &gpio124i_pins
-			&gpio125i_pins
-	                &gpio126i_pins
-		        &gpio127i_pins
-			&gpio136i_pins
-	                &gpio137oh_pins
-		        &gpio138i_pins
-			&gpio139i_pins
-	                &gpio140i_pins
-		        &gpio141i_pins
-			&gpio144i_pins
-	                &gpio145i_pins
-		        &gpio146i_pins
-	                &gpio147oh_pins
-		        &gpio161ol_pins
-	                &gpio162oh_pins
-		        &gpio163i_pins
-	                &gpio167ol_pins
-		        &gpio168ol_pins
-	                &gpio169oh_pins
-		        &gpio170ol_pins
-	                &gpio175oh_pins
-		        &gpio176ol_pins
-	                &gpio177i_pins
-		        &gpio190oh_pins
-	                &gpio191oh_pins
-		        &gpio194oh_pins
-			&gpio195ol_pins
-	                &gpio196ol_pins
-		        &gpio197oh_pins
-	                &gpio199i_pins
-		        &gpio202ol_pins
+			/* LED Pins*/
+			//&gpio7oh_pins
+			&gpio24ol_pins
+			&gpio169ol_pins
+
+			/* Mux Pins */
+			/* UART Mux*/
+			&gpio167oh_pins
+			&gpio161oh_pins
+			&gpio177oh_pins
+			&gpio198ol_pins
+
+			&gpio87oh_pins
+			&gpio88oh_pins
+			&gpio89oh_pins
+			&gpio91oh_pins
+			&gpio168oh_pins
+			&gpio12oh_pins
+			&gpio218oh_pins
+			&gpio164ol_pins
+			&gpio16oh_pins
+			&gpio84ol_pins
+			&gpio85ol_pins
+			&gpio86ol_pins
+			&gpio120ol_pins
+
+			/* Control Pins */
+			&gpio10ol_pins
+			&gpio69ol_pins
 			&gpio203ol_pins
-	                &gpio218oh_pins
-		        &gpio219oh_pins
+			&gpio70oh_pins
+			&gpio94ol_pins
+			&gpio90oh_pins
+			&gpio196ol_pins
+			&gpio197oh_pins
+			&gpio14oh_pins
+			&gpio66ol_pins
+			&gpio67ol_pins
+			&gpio125ol_pins
+			&gpio4ol_pins
+			&gpio5ol_pins
+			&gpio46ol_pins
+			&gpio187ol_pins
+			&gpio165ol_pins
+			&gpio166ol_pins
+			&gpio77oh_pins
+			&gpio170ol_pins
+			&gpio206oh_pins
+			&gpio175ol_pins
+			&gpio219oh_pins
+			&gpio15oh_pins
+			&gpio139ol_pins
+			&gpio141oh_pins
+			&gpio202ol_pins
+
+			/* Monitor Pins */
+			&gpio192i_pins
+			&gpio199i_pins
+			&gpio13i_pins
+			&gpio25i_pins
+			&gpio59i_pins
+			&gpio60i_pins
+			&gpio6i_pins
+			&gpio11i_pins
+			&gpio162i_pins
+			&gpio163i_pins
+			&gpio37i_pins
+			&gpio93i_pins
+			&gpio64i_pins
+			&gpio68i_pins
+			&gpio71i_pins
+			&gpio72i_pins
+			&gpio73i_pins
+			&gpio74i_pins
+			&gpio75i_pins
+			&gpio76i_pins
+			&gpio78i_pins
+			&gpio79i_pins
+			&gpio80i_pins
+			&gpio81i_pins
+			&gpio82i_pins
+			&gpio83i_pins
+			&gpio144i_pins
+			&gpio145i_pins
+			&gpio146i_pins
+			&gpio147i_pins
+			&gpio160i_pins
+			&gpio231i_pins
+			&gpio9i_pins
+			&gpio38i_pins
+			&gpio39i_pins
+			&gpio40i_pins
+			&gpio92i_pins
+			&gpio121i_pins
+			&gpio122i_pins
+			&gpio123i_pins
+			&gpio124i_pins
+			&gpio126i_pins
+			&gpio136i_pins
+			&gpio138i_pins
+			&gpio140i_pins
+			&gpio142i_pins
+			&gpio190i_pins
+			&gpio194i_pins
+			&gpio195i_pins
+
+			// BSP RX/TX
+			&bmcuart0a_pins /* BSP RX/TX */
+			// BU1 RX/TD
+			&bmcuart1_pins /* BU1 RX/TD */
+			// TX/RX D2
+			&uart2_pins /* TX/RX D2 */
+			// Set system reset to high
+			&gpio65oh_pins
+			&gpio127oh_pins
 			>;
 	};
 };


### PR DESCRIPTION
Modified GPIOs in u-boot dts/dtsi for Fii kudo project to match the current configuration in the Fii kudo kernel dts.

Signed-off-by: Brandon Ong <brandon.ong@fii-usa.com>