### PR TITLE
dts: npcm730 GSZ: update the GPIO default setting

### DIFF
--- a/arch/arm/dts/nuvoton-npcm730-gsz-pincfg.dtsi
+++ b/arch/arm/dts/nuvoton-npcm730-gsz-pincfg.dtsi
@@ -113,7 +113,7 @@
 		gpio32pp_pins: gpio32pp-pins {
 			pins = "GPIO32/nSPI0CS1";
 			bias-disable;
-			output-high;
+			output-low;
 			drive-push-pull;
 			persist-enable;
 		};
@@ -478,7 +478,7 @@
 		gpio187pp_pins: gpio187pp-pins {
 			pins = "GPIO187/nSPI3CS1";
 			bias-disable;
-			output-low;
+			output-high;
 			drive-push-pull;
 			persist-enable;
 		};

--- a/arch/arm/dts/nuvoton-npcm730-gsz.dts
+++ b/arch/arm/dts/nuvoton-npcm730-gsz.dts
@@ -4,8 +4,12 @@
 #include "nuvoton-npcm730.dts"
 #include "nuvoton-npcm730-gsz-pincfg.dtsi"
 / {
-	model = "Quanta npcm730 BMC Board (Device Tree v00.05e)";
+	model = "Quanta npcm730 BMC Board (Device Tree v00.07)";
 	compatible = "nuvoton,poleg", "quanta,gsz";
+
+    config {
+            espi-channel-support = <0xf>;
+    };
 
 	pinctrl: pinctrl@f0800000 {
 		compatible = "nuvoton,npcm7xx-pinctrl";


### PR DESCRIPTION
1.Change GPIO32 to output-low.
2.Change GPIO187 to output-high.
3.Update the eSPI setting.

Signed-off-by: Fran Hsu <fran.hsu@quantatw.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
