### PR TITLE
npcm7xx: fix mmc probe fail

### DIFF
--- a/arch/arm/dts/nuvoton-npcm750-buv.dts
+++ b/arch/arm/dts/nuvoton-npcm750-buv.dts
@@ -37,7 +37,7 @@
 		fiu0 = &fiu0;
 		fiu1 = &fiu3;
 		fiu2 = &fiux;
-		mmc1 = &sdhci1;
+		mmc0 = &sdhci0;
 		gpio0 = &gpio0;
 		gpio1 = &gpio1;
 		gpio2 = &gpio2;

--- a/board/nuvoton/poleg/poleg.c
+++ b/board/nuvoton/poleg/poleg.c
@@ -227,7 +227,7 @@ int board_init(void)
 		/* set Graphic Reset Delay to fix host stuck */
 		writel((readl(&gcr->intcr3) | (0x7 << INTCR3_GFXRSTDLY) ), &gcr->intcr3);;
 
-		board_sd_clk_init("mmc1");
+		board_sd_clk_init("mmc0");
 	}
 
 	nodeoff = -1;


### PR DESCRIPTION
update DTS and poleg.c for mmc1 move to mmc0

fix issues:
  mmc0: error -84 whilst initialising MMC card (linux)
  unable to select a mode : -70 error while read data from mmc (UBoot)

Signed-off-by: Brian Ma <chma0@nuvoton.com>

