### PR TITLE
spi-nor-id: add support for Google-Hoth

### DIFF
--- a/drivers/mtd/spi/Kconfig
+++ b/drivers/mtd/spi/Kconfig
@@ -126,6 +126,11 @@ config SPI_FLASH_GIGADEVICE
 	help
 	  Add support for various GigaDevice SPI flash chips (GD25xxx)
 
+config SPI_FLASH_GOOGLE
+	bool "Google SPI flash support"
+	help
+	  Add support for various Google SPI flash devices (Hoth)
+
 config SPI_FLASH_ISSI
 	bool "ISSI SPI flash support"
 	help

--- a/drivers/mtd/spi/spi-nor-ids.c
+++ b/drivers/mtd/spi/spi-nor-ids.c
@@ -63,6 +63,11 @@
  * old entries may be missing 4K flag.
  */
 const struct flash_info spi_nor_ids[] = {
+#ifdef CONFIG_SPI_FLASH_GOOGLE		/* GOOGLE */
+	{INFO("hoth-512",	0x260217, 0x0, 64 * 1024,   512, SECT_4K) },
+	{INFO("hoth-1024",	0x26021a, 0x0, 64 * 1024,  1024, SECT_4K) },
+	{INFO("hoth2-1024",	0x26221a, 0x0, 64 * 1024,  1024, SECT_4K) },
+#endif
 #ifdef CONFIG_SPI_FLASH_ATMEL		/* ATMEL */
 	/* Atmel -- some are (confusingly) marketed as "DataFlash" */
 	{ INFO("at26df321",	0x1f4700, 0, 64 * 1024, 64, SECT_4K) },


### PR DESCRIPTION
add entry to support Google Hoth devices.

Signed-off-by: Jason Ling <jasonling@google.com>
