### PR TITLE
dts: nuvoton-npcm845: enable FIU3 voltage configuration

### DIFF
--- a/arch/arm/dts/nuvoton-npcm845-evb.dts
+++ b/arch/arm/dts/nuvoton-npcm845-evb.dts
@@ -91,6 +91,14 @@
 		regulator-max-microvolt = <3300000>;
 		regulator-always-on;
 	};
+
+	vsbv5: vsbv5 {
+		compatible = "regulator-npcm845";
+		regulator-name = "v5";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+	};
 };
 
 &serial0 {
@@ -126,6 +134,8 @@
 &fiu3 {
 	pinctrl-0 = <&spi3_pins>, <&spi3quad_pins>;
 	status = "okay";
+	vqspi-supply = <&vsbv5>;
+	vqspi-microvolt = <3300000>;
 	spi-nor@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;


### PR DESCRIPTION
Default value is 3.3v for FIU3.

If 1.8v is required, please modify the following property value in fiu3 node.

vqspi-microvolt = <1800000>;

Signed-off-by: Tyrone Ting <kfting@nuvoton.com>

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
