### PR TITLE
configs: poleg: Reserve memory for kernel panic dmesg

### DIFF
--- a/include/configs/poleg.h
+++ b/include/configs/poleg.h
@@ -105,4 +105,6 @@
 		"usb_run=usb start; fatload usb 0 10000000 image-bmc; bootm 10200000\0"   \
 		"\0"
 
+#define CONFIG_PRAM                     128 /* Reserve 128 KB for ramoops */
+
 #endif


### PR DESCRIPTION
This is a follow up patch to https://github.com/Nuvoton-Israel/u-boot/pull/10. After enabling kernel panic on oops, we'd like to store the panic dmesg, which requires reserving a fixed location in ram.
