### PR TITLE
board: nuvoton: arbel: Correct CONFIG_SYS_MEM_TOP_HIDE value

### DIFF
--- a/board/nuvoton/arbel/Kconfig
+++ b/board/nuvoton/arbel/Kconfig
@@ -11,8 +11,8 @@ config SYS_CONFIG_NAME
 
 config SYS_MEM_TOP_HIDE
 	hex "Reserved TOP memory"
-	default 0xB000000
+	default 0xB300000
 	help
-	  Reserve memory for ECC/GFX/VCD/ECE.
+	  Reserve memory for ECC/GFX/OPTEE/TIP/CP.
 
 endif


### PR DESCRIPTION
Correct CONFIG_SYS_MEM_TOP_HIDE value to 0xB300000 (179MB), which reserve memory for ECC/GFX/OPTEE/TIP/CP as follows.

+-------------+-----------+---------------+--------------+
|   Column    | Size (MB) | Offset in Hex | Offset in MB |
+-------------+-----------+---------------+--------------+
| DDR TOP     |           |    40000000   |     1024     |
| DDR ECC     |    128    |    38000000   |      896     |
| GFX         |     16    |    37000000   |      880     |
| OPTEE       |     16    |    36000000   |      864     |
| Reserved    |      1    |    35F00000   |      863     |
| TIP own DDR |     16    |    34F00000   |      847     |
| CP          |      2    |    34D00000   |      845     |
+-------------+-----------+---------------+--------------+
              |  sum 179  |
              +-----------+

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
