### PR TITLE
tools: env: use /run to store lockfile

### DIFF
--- a/tools/env/fw_env_main.c
+++ b/tools/env/fw_env_main.c
@@ -206,7 +206,7 @@ int parse_setenv_args(int argc, char *argv[])
 
 int main(int argc, char *argv[])
 {
-	char *lockname = "/var/lock/" CMD_PRINTENV ".lock";
+	char *lockname = "/run/" CMD_PRINTENV ".lock";
 	int lockfd = -1;
 	int retval = EXIT_SUCCESS;
 	char *_cmdname;


### PR DESCRIPTION
Symptom:
clear-once.service and trace-enable.service were crash.

Root cause:
Upstream systemd made the inclusion of the tmpfiles.d/legacy.conf a feature
that is only provided if the sysvinit PACKAGE is set.
By default, systemd upstream sets this but OpenBMC overrides that in this file.

The legacy.conf provides among other things, a creation of the /run/lock dir.
fw_printenv and fw_setenv rely on the /run/lock directory being present.
clear-once.service and trace-enable.service are using this kind of application.

Solution:
The current location /var/lock is considered legacy (at least bysystemd).
Just use /run to store the lockfile and append the usual .lock suffix.

Tested:
Verified /run/lock is now present and that fw_printenv worked.
clear-once.service and trace-enable.service both run normally without failure.

Signed-off-by: Tim Lee <timlee660101@gmail.com>