### PR TITLE
drivers: spi: fix compiler warnings from npcm_fiu_spi_probe

### DIFF
--- a/drivers/spi/npcm_fiu_spi.c
+++ b/drivers/spi/npcm_fiu_spi.c
@@ -11,6 +11,7 @@
 #include <linux/bitfield.h>
 #include <linux/log2.h>
 #include <linux/iopoll.h>
+#include <power/regulator.h>
 
 #define DW_SIZE			4
 #define CHUNK_SIZE		16


### PR DESCRIPTION
Symptom:
drivers/spi/npcm_fiu_spi.c: In function 'npcm_fiu_spi_probe': drivers/spi/npcm_fiu_spi.c:390:3: warning: implicit declaration of function 'device_get_supply_regulator' [-Wimplicit-function-declaration] device_get_supply_regulator(bus, "vqspi-supply", &vqspi_supply); ^~~~~~~~~~~~~~~~~~~~~~~~~~~

Root cause:
Lack of declaration power/regulator.h include file.

Solution:
Adding the “#include <power/regulator.h>” to fix this kind of warnings.

Signed-off-by: Tim Lee <timlee660101@gmail.com>