### PR TITLE
gpio: npcm7xx: output state before enabling the output

### DIFF
--- a/drivers/gpio/npcm750_gpio.c
+++ b/drivers/gpio/npcm750_gpio.c
@@ -62,10 +62,11 @@ static int npcm_gpio_direction_input(struct udevice *dev, unsigned offset)
 static int npcm_gpio_direction_output(struct udevice *dev, unsigned offset,
 					  int value)
 {
+	npcm_gpio_offset_write(dev, offset, NPCM_GPIO_REG_DOUT, value);
+
 	npcm_gpio_offset_write(dev, offset, NPCM_GPIO_REG_IEM, 0);
 	npcm_gpio_offset_write(dev, offset, NPCM_GPIO_REG_OES, 1);
 
-	npcm_gpio_offset_write(dev, offset, NPCM_GPIO_REG_DOUT, value);
 	return 0;
 }
 

--- a/drivers/pinctrl/nuvoton/pinctrl-npcm7xx.c
+++ b/drivers/pinctrl/nuvoton/pinctrl-npcm7xx.c
@@ -1535,12 +1535,12 @@ static int npcm7xx_pinconf_set(struct udevice *dev, unsigned int pin,
 		setbits_le32(base + NPCM7XX_GP_N_OES, BIT(gpio));
 	case PIN_CONFIG_OUTPUT:
 		dev_dbg(dev, "set pin %d output %d \n", pin, arg);
-		clrbits_le32(base + NPCM7XX_GP_N_IEM, BIT(gpio));
-		setbits_le32(base + NPCM7XX_GP_N_OES, BIT(gpio));
 		if (arg)
 			setbits_le32(base + NPCM7XX_GP_N_DOUT, BIT(gpio));
 		else
 			clrbits_le32(base + NPCM7XX_GP_N_DOUT, BIT(gpio));
+		clrbits_le32(base + NPCM7XX_GP_N_IEM, BIT(gpio));
+		setbits_le32(base + NPCM7XX_GP_N_OES, BIT(gpio));
 		break;
 	case PIN_CONFIG_DRIVE_PUSH_PULL:
 		dev_dbg(dev, "set pin %d push pull \n", pin);


### PR DESCRIPTION
The default output state may be different to request, change the configuration sequence to avoid glitch.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
