### PR TITLE
mpcm8xx: fix reset reason issue for bootup

### DIFF
--- a/arch/arm/include/asm/arch-npcm8xx/gcr.h
+++ b/arch/arm/include/asm/arch-npcm8xx/gcr.h
@@ -163,7 +163,9 @@
 #define  INTCR_KCSRST_MODE          0
 
 /* Integration Control Register (INTCR2) */
-#define  INTCR2_WDC                   21
+#define  INTCR2_WDC		21
+#define  INTCR2_PORST		BIT(31)
+#define  INTCR2_CORST		BIT(30)
 
 /* Integration Control Register (INTCR3) */
 #define  INTCR3_USBLPBK2              31          /* USB loop-backed HOST 1/2 */

--- a/board/nuvoton/arbel/arbel.c
+++ b/board/nuvoton/arbel/arbel.c
@@ -106,6 +106,17 @@ static void arbel_clk_init(void)
 
 int board_init(void)
 {
+	struct npcm_gcr *gcr = (struct npcm_gcr *)npcm_get_base_gcr();
+
+	u32 val;
+
+        val = readl(&gcr->intcr2);
+	if((val & INTCR2_CORST) && (val & INTCR2_PORST))
+	{
+		val &= ~INTCR2_CORST;
+		writel(val, &gcr->intcr2);
+	}
+
 	arbel_clk_init();
 	arbel_eth_init();
 


### PR DESCRIPTION
int non tip mode, BMC first power on with PORST+CORST. the gpio status will wrong.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
