### PR TITLE
cmd: Reset GFX PCI before configuration

### DIFF
--- a/arch/arm/include/asm/arch-npcm8xx/gfx.h
+++ b/arch/arm/include/asm/arch-npcm8xx/gfx.h
@@ -13,6 +13,7 @@
 #define INTCR3				(GCR_BA+0x09C)		// Integration Control 3
 #define MFSEL4				(GCR_BA+0x26C)		// Multiple function Pin Select 4
 #define INTCR4				(GCR_BA+0x0C0)		// Multiple function Pin Select 4
+#define PCIRCTL				(GCR_BA+0x0A0)		// PCI Reset Control
 
 /*----- Clock Controller -----*/
 #define CLK_BA				0xF0801000

--- a/cmd/gfx_test.c
+++ b/cmd/gfx_test.c
@@ -421,6 +421,8 @@ int GFX_ConfigureDisplayTo1920x1200(GFX_ColorDepth colorDepth)
 	u32	data;
 	int		i , cnt = 0;
 
+	gfx_ip_reset();
+
 	if(FB_Initialize() == 0)
 		return(false);
 	// Wait until GFX Device/Vendor ID is read correctly
@@ -780,6 +782,8 @@ int GFX_ConfigureDisplayTo1024x768(GFX_ColorDepth colorDepth)
 	u32	data;
 	int		i , cnt=0;
 
+	gfx_ip_reset();
+
 	if(FB_Initialize() == 0)
 		return(false);
 	/*----------------------------------------------------------------------------------------------*/
@@ -1131,6 +1135,31 @@ int GFX_ConfigureDisplayTo1024x768(GFX_ColorDepth colorDepth)
 	return (true);
 }
 
+/* Reset PCI domain and GFX logic */
+void gfx_ip_reset()
+{
+	u32 ipsrsttwoval = 0;
+
+#ifdef CONFIG_ARCH_NPCM8XX
+	/* Reset PCI */
+	writel(8, PCIRCTL);
+
+	/* Release PCI Reset and allow external PCI reset clear the internal control of reset */
+        writew((1 << 1 ) | (1 << 0), PCIRCTL); /* 11b 3h */
+#endif
+
+	/* Reset GFX logic */
+	ipsrsttwoval = readl(IPSRST2);
+	writel((ipsrsttwoval | BIT(10)), IPSRST2);
+
+	ipsrsttwoval = readl(IPSRST2);
+	printf(">IPSRST2: 0x%8x\n", ipsrsttwoval);
+
+	writel((ipsrsttwoval & ~BIT(10)), IPSRST2);
+
+	printf(">Reset graphics controller and PCIe to PCI bridge finish.\n");
+	printf(">IPSRST2: 0x%8x\n", (ipsrsttwoval & ~BIT(10)));
+}
 
 int GFX_Draw_Pattern(int out_color)
 {


### PR DESCRIPTION
Reset GFX PCI before configuration to prevent read timeout.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
