### PR TITLE
i2c: npcm: enable support Fast mode

### DIFF
--- a/drivers/i2c/i2c-npcm.c
+++ b/drivers/i2c/i2c-npcm.c
@@ -517,11 +517,6 @@ static int npcm_i2c_init_clk(struct npcm_i2c_bus *bus, u32 bus_freq)
 	u32 sclfrq;
 	u8 hldt, val;
 
-	if (bus_freq > I2C_FREQ_100K) {
-		printf("Support standard mode only\n");
-		return -EINVAL;
-	}
-
 	/* SCLFRQ = T(SCL)/4/T(CLK) = FREQ(CLK)/4/FREQ(SCL) */
 	sclfrq = freq / (bus_freq * 4);
 	if (sclfrq < SCLFRQ_MIN || sclfrq > SCLFRQ_MAX)


### PR DESCRIPTION
Symptom:
When setting i2c speed 400k that got failed:
U-Boot>i2c speed 400000
Setting bus speed to 400000 Hz
Support standard mode only
Failure changing bus speed (-22)

Root cause:
Default only support Standard mode.

Solution:
Enable support Fast mode.

Tested:
U-Boot>i2c dev 0
Setting bus to 0
I2C bus 0 ready. speed=100000, base=0xf0080000, apb=62500000 U-Boot>i2c speed
Current bus speed=100000
U-Boot>i2c speed 400000
Setting bus speed to 400000 Hz
U-Boot>i2c speed
Current bus speed=400000