### PR TITLE
cmd: fuse: casting u32 to u8 if CONFIG_NPCM

### DIFF
--- a/cmd/fuse.c
+++ b/cmd/fuse.c
@@ -76,7 +76,7 @@ static int do_fuse(struct cmd_tbl *cmdtp, int flag, int argc,
 				goto err;
 
 			if (IS_ENABLED(CONFIG_NPCM_OTP))
-				printf(" %.2x", val);
+				printf(" %.2x", (u8)val);
 			else
 				printf(" %.8x", val);
 		}


### PR DESCRIPTION
In poleg, fuse read would print dummy byte data,
U-Boot>fuse read 0 0 16
Reading bank 0:

Byte 0x0000: 3cd11300 3cd11300 3cd11300 3cd11300 3cd11300 3cd11300 3cd11300 3cd11300 3cd11300 3cd11300 3cd11300 3cd11300 3cd11300 3cd11300 3cd11300 3cd11300

In arbel, fuse read would print correct data.
U-Boot>fuse read 0 0 16
Reading bank 0:

Byte 0x0000: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
