### PR TITLE
configs: arbel: increase u-boot mapping size

### DIFF
--- a/include/configs/arbel.h
+++ b/include/configs/arbel.h
@@ -16,7 +16,7 @@
 #define CONFIG_SYS_CBSIZE               256
 #define CONFIG_SYS_PBSIZE               (CONFIG_SYS_CBSIZE + sizeof(CONFIG_SYS_PROMPT) + 16)
 #define CONFIG_SYS_BOOTM_LEN            (20 << 20)
-#define CONFIG_SYS_BOOTMAPSZ            (128 << 20)
+#define CONFIG_SYS_BOOTMAPSZ            (192 << 20)
 #define CONFIG_SYS_LOAD_ADDR            CONFIG_SYS_TEXT_BASE
 #define CONFIG_SYS_SDRAM_BASE           0x0
 #define CONFIG_SYS_INIT_SP_ADDR         CONFIG_SYS_TEXT_BASE


### PR DESCRIPTION
when u-boot enable CONFIG_SYS_BOOT_RAMDISK_HIGH, rootfs image relocated from FIU address space to memory address before jump to kernel.

since Arbel reserved memory from 0x00000000 to 0x06200000 for tip image, and rootfs image may too large that cannot found a suitable location before 128MB(0x8000000), so increase mapping size from 128MB to 192MB.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
