### PR TITLE
env: add stopwdt command in default environment

### DIFF
--- a/include/configs/arbel.h
+++ b/include/configs/arbel.h
@@ -45,6 +45,7 @@
 		"tftptimeout=1000\0" \
 		"tftptimeoutcountmax=50\0" \
 		"bootpretryperiod=60000\0" \
+		"stopwdt=wdt dev watchdog@901c; wdt stop\0" \
 		"\0"
 
 #endif


### PR DESCRIPTION
Due to we will enable WD1 about 120 seconds after bootblock finish DDR initialization, add stopwdt command once we need stay in U-Boot.


