### PR TITLE
board: poleg: fix build failure in last_stage_init

### DIFF
--- a/board/nuvoton/poleg_evb/poleg_evb.c
+++ b/board/nuvoton/poleg_evb/poleg_evb.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2021 Nuvoton Technology Corp.
  */
 
+#include <bootm.h>
 #include <common.h>
 #include <dm.h>
 #include <env.h>


### PR DESCRIPTION
There is build failure in function 'last_stage_init',
and this failure noticed only "gbs" machine.

/data0/jenkins/workspace/ci-openbmc/distro/ubuntu/label
/docker-builder/target/gbs/build/work/gbs-openbmc-linux-gnueabi
/u-boot-nuvoton/v2023.10+git/git/board/nuvoton/
poleg_evb/poleg_evb.c :79:9:
error: implicit declaration of function 'arch_preboot_os'

Required all commits from this chain to recreate the failure.
https://gerrit.openbmc.org/c/openbmc/openbmc/+/72220/9