### PR TITLE
board: arbel_evb: support select CS for env

### DIFF
--- a/board/nuvoton/arbel_evb/Kconfig
+++ b/board/nuvoton/arbel_evb/Kconfig
@@ -15,5 +15,13 @@ config SYS_MEM_TOP_HIDE
 	help
 	  Reserve memory for ECC/GFX/OPTEE/TIP/CP.
 
+config ENV_SPI_CS
+	hex "SPI Chip select for Normal boot ENV"
+	default 0x00
+
+config ENV_SPI_CS_RECOVERY
+	hex "SPI Chip select for Recovery boot ENV"
+	default 0x01
+
 source "board/nuvoton/common/Kconfig"
 endif

--- a/board/nuvoton/arbel_evb/arbel_evb.c
+++ b/board/nuvoton/arbel_evb/arbel_evb.c
@@ -7,6 +7,7 @@
 #include <dm.h>
 #include <asm/io.h>
 #include <linux/bitfield.h>
+#include <asm/arch/gfx.h>
 #include <asm/arch/gcr.h>
 #include "../common/common.h"
 
@@ -113,4 +114,18 @@ int last_stage_init(void)
 	board_set_console();
 
 	return 0;
+}
+
+/**
+ * spi_get_env_cs : return spi chipselect based on normal boot or recovery boot
+ */
+int spi_get_env_cs(void)
+{
+	if((readl(INTCR2) & INTCR2_WDC) == INTCR2_WDC)
+	{
+		printf("Detected Recovery mode. Using CS %d for env\n", CONFIG_ENV_SPI_CS_RECOVERY);
+		return CONFIG_ENV_SPI_CS_RECOVERY;
+	}
+	printf("Detected Normal mode. Using CS %d for env\n", CONFIG_ENV_SPI_CS);
+	return CONFIG_ENV_SPI_CS;
 }


### PR DESCRIPTION
Add support to load the proper u-boot env data according to normal or recovery boot source.

Tested:
Normal mode log: Detected Normal mode. Using CS 0 for env
Recovery mode log: Detected Recovery mode. Using CS 1 for env
