### PR TITLE
image: Avoid erroneous double byte-swap in CRC value

### DIFF
--- a/common/image-fit.c
+++ b/common/image-fit.c
@@ -1192,12 +1192,6 @@ int fit_set_timestamp(void *fit, int noffset, time_t timestamp)
 	return 0;
 }
 
-static void crc32_uimage_fixup(void *value)
-{
-	/* TODO: In C, this type punning is undefined behavior: */
-	*((uint32_t *)value) = cpu_to_uimage(*((uint32_t *)value));
-}
-
 /**
  * calculate_hash - calculate and return hash for provided input data
  * @data: pointer to the input data
@@ -1230,9 +1224,6 @@ int calculate_hash(const void *data, int data_len, const char *name,
 
 	algo->hash_func_ws(data, data_len, value, algo->chunk_size);
 	*value_len = algo->digest_size;
-
-	if (!strcmp(name, "crc32"))
-		crc32_uimage_fixup(value);
 
 	return 0;
 }


### PR DESCRIPTION
The hash algorithm selection was streamlined in commit 92055e138f28
("image: Drop if/elseif hash selection in calculate_hash()"). Said
commit kept the call to cpu_to_uimage() to convert the CRC to big
endian format.

This would have been correct when calling crc32_wd(). However, the
->hash_func_ws member of crc32 points to crc32_wd_buf(), which already
converts the CRC to big endian. On a little endian host, doing both
conversions results in a little-endian CRC. This is incorrect.

To remedy this, simply drop the call to cpu_to_uimage(), thus only
doing the byte-order conversion once.

Fixes: 92055e138f28 ("image: Drop if/elseif hash selection in
	   calculate_hash()")
Tested-by: Tom Rini <trini@konsulko.com>
Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>


Signed-off-by: Tim Lee <chli30@nuvoton.com>