### PR TITLE
cmd: ums: find the correct usb controller for ums command

### DIFF
--- a/cmd/usb_mass_storage.c
+++ b/cmd/usb_mass_storage.c
@@ -175,6 +175,7 @@ static int do_usb_mass_storage(struct cmd_tbl *cmdtp, int flag,
 		goto cleanup_board;
 	}
 
+	usb_setup_gadget_controller_idx(controller_index);
 	rc = g_dnl_register("usb_dnl_ums");
 	if (rc) {
 		pr_err("g_dnl_register failed\n");

--- a/drivers/usb/host/usb-uclass.c
+++ b/drivers/usb/host/usb-uclass.c
@@ -19,6 +19,7 @@
 #include <dm/uclass-internal.h>
 
 static bool asynch_allowed;
+static unsigned int controller_index;
 
 struct usb_uclass_priv {
 	int companion_device_count;
@@ -392,6 +393,11 @@ int usb_init(void)
 	return usb_started ? 0 : -ENOENT;
 }
 
+void usb_setup_gadget_controller_idx(unsigned int controller_idx)
+{
+	controller_index = controller_idx;
+}
+
 int usb_setup_ehci_gadget(struct ehci_ctrl **ctlrp)
 {
 	struct usb_plat *plat;
@@ -399,7 +405,7 @@ int usb_setup_ehci_gadget(struct ehci_ctrl **ctlrp)
 	int ret;
 
 	/* Find the old device and remove it */
-	ret = uclass_find_first_device(UCLASS_USB, &dev);
+	ret = uclass_find_device_by_seq(UCLASS_USB, controller_index, &dev);
 	if (ret)
 		return ret;
 	ret = device_remove(dev, DM_REMOVE_NORMAL);
@@ -422,7 +428,7 @@ int usb_remove_ehci_gadget(struct ehci_ctrl **ctlrp)
 	int ret;
 
 	/* Find the old device and remove it */
-	ret = uclass_find_first_device(UCLASS_USB, &dev);
+	ret = uclass_find_device_by_seq(UCLASS_USB, controller_index, &dev);
 	if (ret)
 		return ret;
 	ret = device_remove(dev, DM_REMOVE_NORMAL);

--- a/include/usb.h
+++ b/include/usb.h
@@ -911,6 +911,7 @@ int usb_child_pre_probe(struct udevice *dev);
 
 struct ehci_ctrl;
 
+void usb_setup_gadget_controller_idx(unsigned int controller_idx);
 /**
  * usb_setup_ehci_gadget() - Set up a USB device as a gadget
  *


### PR DESCRIPTION
ums command can specify the usb controller but the usb uclass driver always use the first UCLASS_USB device. Add uclass driver API to let ums can set the specific usb controller to be used for the usb gadget.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
