### PR TITLE
npcm_otp: read fuse bytes with byte offset

### DIFF
--- a/cmd/fuse.c
+++ b/cmd/fuse.c
@@ -66,14 +66,22 @@ static int do_fuse(struct cmd_tbl *cmdtp, int flag, int argc,
 
 		printf("Reading bank %u:\n", bank);
 		for (i = 0; i < cnt; i++, word++) {
-			if (!(i % 4))
-				printf("\nWord 0x%.8x:", word);
+			if (IS_ENABLED(CONFIG_NPCM_OTP)) {
+				if (!(i % 16))
+					printf("\nByte 0x%.4x:", word);
+			} else {
+				if (!(i % 4))
+					printf("\nWord 0x%.8x:", word);
+			}
 
 			ret = fuse_read(bank, word, &val);
 			if (ret)
 				goto err;
 
-			printf(" %.8x", val);
+			if (IS_ENABLED(CONFIG_NPCM_OTP))
+				printf(" %.2x", (u8)val);
+			else
+				printf(" %.8x", val);
 		}
 		putc('\n');
 	} else if (!strcmp(op, "readm")) {
@@ -142,7 +150,11 @@ static int do_fuse(struct cmd_tbl *cmdtp, int flag, int argc,
 			if (strtou32(argv[i], 16, &val))
 				return CMD_RET_USAGE;
 
-			printf("Programming bank %u word 0x%.8x to 0x%.8x...\n",
+			if (IS_ENABLED(CONFIG_NPCM_OTP))
+				printf("Programming bank %u byte 0x%.4x to 0x%.2x...\n",
+					bank, word, val);
+			else
+				printf("Programming bank %u word 0x%.8x to 0x%.8x...\n",
 					bank, word, val);
 			if (!confirmed && !confirm_prog())
 				return CMD_RET_FAILURE;

--- a/drivers/misc/npcm_otp.c
+++ b/drivers/misc/npcm_otp.c
@@ -434,13 +434,10 @@ int fuse_prog_image(u32 bank, uintptr_t address)
 
 int fuse_read(u32 bank, u32 word, u32 *val)
 {
-	int rc = npcm_otp_check_inputs(bank, word);
+	if (npcm_otp_check_inputs(bank, word) != 0)
+		return -1;
 
-	if (rc != 0)
-		return rc;
-
-	*val = 0;
-	npcm_otp_read_byte((u32)bank, word, (u8 *)val);
+	npcm_otp_read_byte(bank, word, (u8 *)val);
 
 	return 0;
 }


### PR DESCRIPTION
example: read 32 bytes from fuse bank 0 offset 16
U-Boot>fuse read 0 16 32
Reading bank 0:

Byte 0x0010: 00 00 00 02 00 00 00 02 00 00 00 02 00 00 00 00
Byte 0x0020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
