### PR TITLE
board: arbel_evb: Setup power voltage at boot time

### DIFF
--- a/board/nuvoton/arbel/arbel.c
+++ b/board/nuvoton/arbel/arbel.c
@@ -15,6 +15,7 @@
 #include <asm/mach-types.h>
 #include <linux/bitfield.h>
 #include <linux/delay.h>
+#include <power/regulator.h>
 
 #ifdef CONFIG_EXT_TPM2_SPI
 #include <mapmem.h>
@@ -108,6 +109,9 @@ static void arbel_clk_init(void)
 int board_init(void)
 {
 
+#ifdef CONFIG_DM_REGULATOR
+	regulators_enable_boot_on(false);
+#endif
 	arbel_clk_init();
 	arbel_eth_init();
 


### PR DESCRIPTION
Setup power voltage according to DTS setting at boot time.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
