### PR TITLE
cmd: espi uart: wait for THRE before writing data

### DIFF
--- a/cmd/espi.c
+++ b/cmd/espi.c
@@ -1585,7 +1585,7 @@ static int espi_iowr8(u16 addr, u8 data)
 
 	return espi_put_iowr(addr, &data, 1, resp);
 }
-#if 0
+
 static int espi_iowr16(u16 addr, u16 data)
 {
 	u8 resp[MAX_RESP_LEN];
@@ -1628,7 +1628,6 @@ static int espi_iord32(u16 addr, u32 *data)
 
 	return ret;
 }
-#endif
 
 static int do_espi_auto_test(void)
 {
@@ -2617,6 +2616,8 @@ static int do_espi_uart_command(struct cmd_tbl *cmdtp, int flag, int argc, char 
 	if (strcmp(argv[1], "manual") == 0) {
 		ulong addr;
 		ulong len;
+		u8 lsr;
+		int count;
 
 		addr = hextoul(argv[2], NULL);
 		len = hextoul(argv[3], NULL);
@@ -2626,7 +2627,18 @@ static int do_espi_uart_command(struct cmd_tbl *cmdtp, int flag, int argc, char 
 		for ( i = 0; i < len; i++) {
 			sprintf(&data, "%c", nuvoton[i]);
 			espi_put_iowr(0x3f8, &data, 1, resp);
-			udelay(100);
+			count = 1000;
+			while (count--) {
+				espi_iord8(0x3fd, (u8 *)&lsr);
+				/* Check THRE bit */
+				if (lsr & BIT(5))
+					break;
+			}
+			if (count == 0) {
+				printf("uart write timeout\n");
+				break;
+			}
+
 			if (ctrlc())
 				break;
 		}


### PR DESCRIPTION
Wait for THRE(Transmit Holding Register Empty) before writing UART data.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
