### PR TITLE
net: designware: Disable SGMII auto negotiation on NPCM845

### DIFF
--- a/drivers/net/designware.c
+++ b/drivers/net/designware.c
@@ -498,16 +498,33 @@ static int dw_adjust_link(struct dw_eth_dev *priv, struct eth_mac_regs *mac_p,
 	if (phydev->interface == PHY_INTERFACE_MODE_SGMII) {
 		ulong start;
 
-		/* Indirect access to VR_MII_MMD registers */
-		writew((VR_MII_MMD >> 9), PCS_BA + PCS_IND_AC);
-		/* Set PCS_Mode to SGMII */
-		clrsetbits_le16(PCS_BA + VR_MII_MMD_AN_CTRL, BIT(1), BIT(2));
-		/* Set Auto Speed Mode Change */
-		setbits_le16(PCS_BA + VR_MII_MMD_CTRL1, BIT(9));
 		/* Indirect access to SR_MII_MMD registers */
 		writew((SR_MII_MMD >> 9), PCS_BA + PCS_IND_AC);
-		/* Restart Auto-Negotiation */
-		setbits_le16(PCS_BA + SR_MII_MMD_CTRL, BIT(9) | BIT(12));
+		/* Disable SGMII PCS Auto-Negotiation */
+		clrbits_le16(PCS_BA + SR_MII_MMD_CTRL, BIT(12));
+
+		switch (phydev->speed) {
+		    case SPEED_1000:
+			/* SR_MII_CTRL.SS6=1 */
+			setbits_le16(PCS_BA, BIT(6));
+			/* SR_MII_CTRL.SS13=0 */
+			clrbits_le16(PCS_BA, BIT(13));
+			break;
+		    case SPEED_100:
+			/* SR_MII_CTRL.SS6=0 */
+			clrbits_le16(PCS_BA, BIT(6));
+			/* SR_MII_CTRL.SS13=1 */
+			setbits_le16(PCS_BA, BIT(13));
+			break;
+		    case SPEED_10:
+			/* SR_MII_CTRL.SS6=0 */
+			clrbits_le16(PCS_BA, BIT(6));
+			/* SR_MII_CTRL.SS13=0 */
+			clrbits_le16(PCS_BA, BIT(13));
+			break;
+		    default:
+			break;
+		}
 
 		printf("SGMII PHY Wait for link up \n");
 		/* SGMII PHY Wait for link up */


### PR DESCRIPTION
Disable SGMII auto negotiation to avoid link-up timeout on NPCM845.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.
